### PR TITLE
Fix manage apps moving the wrong selected app

### DIFF
--- a/app/src/main/java/com/jeerovan/comfer/AppInfoViewModel.kt
+++ b/app/src/main/java/com/jeerovan/comfer/AppInfoViewModel.kt
@@ -473,8 +473,10 @@ class AppInfoViewModel(application: Application) : AndroidViewModel(application)
         }
     }
 
-    fun moveAppsToList(fromListName: String, toListName: String, appIndexes: List<Int>) {
+    fun moveAppsToList(fromListName: String, toListName: String, selectedPackageNames: Set<String>) {
         viewModelScope.launch {
+            if (selectedPackageNames.isEmpty()) return@launch
+
             val currentState = _uiState.value
             val alphabeticalOrder = PreferenceManager.getAlphabeticalOrder(getApplication())
             val fromList = when (fromListName) {
@@ -484,7 +486,9 @@ class AppInfoViewModel(application: Application) : AndroidViewModel(application)
                 else -> return@launch
             }
 
-            val appsToMove = appIndexes.map { fromList[it] }
+            val appsToMove = fromList.filter { it.packageName in selectedPackageNames }
+            if (appsToMove.isEmpty()) return@launch
+
             val appsToMovePackageNames = appsToMove.map { it.packageName }.toSet()
 
             var newQuickApps = currentState.quickApps

--- a/app/src/main/java/com/jeerovan/comfer/ManageAppListActivity.kt
+++ b/app/src/main/java/com/jeerovan/comfer/ManageAppListActivity.kt
@@ -149,15 +149,6 @@ fun ManageLayersScreen(viewModel: AppInfoViewModel) {
         selectedPackageNames = emptySet()
     }
 
-    // Helper to get indices for the move operation (since ViewModel likely still expects indices)
-    // If your ViewModel can accept packageNames, refactor it to use those instead!
-    // For now, we map back to indices just for the action.
-    fun getSelectedIndices(sourceList: List<AppInfo>): List<Int> {
-        return sourceList
-            .mapIndexedNotNull { index, app -> if (selectedPackageNames.contains(app.packageName)) index else null }
-            .sortedDescending()
-    }
-
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
 
@@ -199,11 +190,10 @@ fun ManageLayersScreen(viewModel: AppInfoViewModel) {
                                     snackbarHostState.showSnackbar("Maximum $MAX_QUICK_APPS apps only")
                                 }
                             } else {
-                                val indices = getSelectedIndices(uiState.primaryApps) // Source is Primary
                                 viewModel.moveAppsToList(
                                     AppInfoManager.PRIMARY_APPS_LIST_NAME,
                                     AppInfoManager.QUICK_APPS_LIST_NAME,
-                                    indices // VM expects indices
+                                    selectedPackageNames
                                 )
                                 clearSelection()
                             }
@@ -223,11 +213,10 @@ fun ManageLayersScreen(viewModel: AppInfoViewModel) {
                         modifier = Modifier.size(40.dp),
                         contentPadding = PaddingValues(0.dp),
                         onClick = {
-                            val indices = getSelectedIndices(uiState.quickApps)
                             viewModel.moveAppsToList(
                                 AppInfoManager.QUICK_APPS_LIST_NAME,
                                 AppInfoManager.PRIMARY_APPS_LIST_NAME,
-                                indices
+                                selectedPackageNames
                             )
                             clearSelection()
                         },
@@ -261,11 +250,10 @@ fun ManageLayersScreen(viewModel: AppInfoViewModel) {
                         modifier = Modifier.size(40.dp),
                         contentPadding = PaddingValues(0.dp),
                         onClick = {
-                            val indices = getSelectedIndices(uiState.restApps)
                             viewModel.moveAppsToList(
                                 REST_LIST_NAME,
                                 AppInfoManager.PRIMARY_APPS_LIST_NAME,
-                                indices
+                                selectedPackageNames
                             )
                             clearSelection()
                         },
@@ -284,11 +272,10 @@ fun ManageLayersScreen(viewModel: AppInfoViewModel) {
                         modifier = Modifier.size(40.dp),
                         contentPadding = PaddingValues(0.dp),
                         onClick = {
-                            val indices = getSelectedIndices(primaryApps)
                             viewModel.moveAppsToList(
                                 AppInfoManager.PRIMARY_APPS_LIST_NAME,
                                 REST_LIST_NAME,
-                                indices
+                                selectedPackageNames
                             )
                             clearSelection()
                         },


### PR DESCRIPTION
## Summary
- Use selected package names instead of derived list indices when moving apps between columns.
- Preserve move order by resolving the selected apps from the source list itself.

## Root cause
The primary apps column can be displayed alphabetically, but the quick-app move action still derived indices from a differently ordered list. When those indices were later applied, a different app could be moved.

## Validation
- `git diff --check`
- `./gradlew.bat :app:compileDebugKotlin`
