### PR TITLE
Normalize legacy app icon fit inside shaped wrappers

### DIFF
--- a/app/src/main/java/com/jeerovan/comfer/AppInfoViewModel.kt
+++ b/app/src/main/java/com/jeerovan/comfer/AppInfoViewModel.kt
@@ -17,9 +17,11 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.core.graphics.ColorUtils
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.drawable.toDrawable
+import androidx.core.graphics.drawable.toBitmap
 import androidx.core.graphics.get
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.palette.graphics.Palette
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -45,7 +47,10 @@ import kotlinx.coroutines.flow.map
 
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
+import kotlin.math.min
 private const val REST_LIST_NAME = "Rest"
+private const val ICON_ANALYSIS_SIZE = 192
+private const val ICON_ALPHA_THRESHOLD = 32
 
 data class AppInfoUiState(
     val quickApps: List<AppInfo> = emptyList(),
@@ -112,9 +117,8 @@ suspend fun getAppInfo(
         }
         val foregroundColor = getThemedIconColor(themedColors, isLightHour)
 
-        // Determine scale
         val isAdaptive = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && iconDrawable is AdaptiveIconDrawable
-        val scale = if (isAdaptive) 1.5f else 0.9f
+        var scale = if (isAdaptive) 1.5f else 1f
 
         // 4. Heavy Image Processing (CPU bound, but fine inside IO context)
         if (isAdaptive && iconDrawable is AdaptiveIconDrawable) {
@@ -144,10 +148,21 @@ suspend fun getAppInfo(
             }
         } else {
             // Legacy / Standard Icons
-            val backgroundColor = if (showThemedIcons) {
+            val iconBitmap = iconDrawable.toBitmap(
+                width = ICON_ANALYSIS_SIZE,
+                height = ICON_ANALYSIS_SIZE,
+                config = Bitmap.Config.ARGB_8888
+            )
+            val fallbackBackgroundColor = if (showThemedIcons) {
                 getThemedBackgroundColor(themedColors, isLightHour)
             } else {
                 getBackgroundColor(isLightHour).toArgb()
+            }
+            scale = calculateLegacyForegroundScale(iconBitmap)
+            val backgroundColor = if (showThemedIcons) {
+                fallbackBackgroundColor
+            } else {
+                derivePropagatedBackgroundColor(iconBitmap, fallbackBackgroundColor)
             }
             backgroundDrawable = backgroundColor.toDrawable()
 
@@ -178,6 +193,95 @@ suspend fun getAppInfo(
         Log.e("getAppInfo", "Failed to load ${info.componentName.packageName}: ${e.message}")
         null
     }
+}
+
+private fun calculateLegacyForegroundScale(bitmap: Bitmap): Float {
+    val bounds = findOpaqueBounds(bitmap) ?: return 1f
+    val contentFraction = max(
+        bounds.width().toFloat() / bitmap.width,
+        bounds.height().toFloat() / bitmap.height
+    )
+    return (0.84f / contentFraction).coerceIn(0.92f, 1.32f)
+}
+
+private fun derivePropagatedBackgroundColor(bitmap: Bitmap, fallbackColor: Int): Int {
+    val edgeColor = sampleEdgeColor(bitmap)
+    val paletteColor = Palette.from(bitmap)
+        .clearFilters()
+        .maximumColorCount(12)
+        .generate()
+        .run {
+            dominantSwatch?.rgb
+                ?: mutedSwatch?.rgb
+                ?: vibrantSwatch?.rgb
+                ?: lightMutedSwatch?.rgb
+                ?: darkMutedSwatch?.rgb
+        }
+
+    val sourceColor = edgeColor ?: paletteColor ?: fallbackColor
+    return ColorUtils.blendARGB(
+        ColorUtils.setAlphaComponent(sourceColor, 255),
+        ColorUtils.setAlphaComponent(fallbackColor, 255),
+        0.15f
+    )
+}
+
+private fun sampleEdgeColor(bitmap: Bitmap): Int? {
+    val edgeInsetX = max(1, bitmap.width / 8)
+    val edgeInsetY = max(1, bitmap.height / 8)
+    var red = 0L
+    var green = 0L
+    var blue = 0L
+    var sampleCount = 0
+
+    for (y in 0 until bitmap.height) {
+        for (x in 0 until bitmap.width) {
+            val isEdgePixel =
+                x < edgeInsetX || x >= bitmap.width - edgeInsetX ||
+                    y < edgeInsetY || y >= bitmap.height - edgeInsetY
+            if (!isEdgePixel) continue
+
+            val pixel = bitmap[x, y]
+            if (android.graphics.Color.alpha(pixel) < ICON_ALPHA_THRESHOLD) continue
+
+            red += android.graphics.Color.red(pixel)
+            green += android.graphics.Color.green(pixel)
+            blue += android.graphics.Color.blue(pixel)
+            sampleCount++
+        }
+    }
+
+    if (sampleCount < 24) return null
+
+    return android.graphics.Color.argb(
+        255,
+        (red / sampleCount).toInt(),
+        (green / sampleCount).toInt(),
+        (blue / sampleCount).toInt()
+    )
+}
+
+private fun findOpaqueBounds(bitmap: Bitmap): android.graphics.Rect? {
+    var minX = bitmap.width
+    var minY = bitmap.height
+    var maxX = -1
+    var maxY = -1
+
+    for (y in 0 until bitmap.height) {
+        for (x in 0 until bitmap.width) {
+            val pixel = bitmap[x, y]
+            if (android.graphics.Color.alpha(pixel) < ICON_ALPHA_THRESHOLD) continue
+
+            minX = min(minX, x)
+            minY = min(minY, y)
+            maxX = max(maxX, x)
+            maxY = max(maxY, y)
+        }
+    }
+
+    if (maxX < minX || maxY < minY) return null
+
+    return android.graphics.Rect(minX, minY, maxX + 1, maxY + 1)
 }
 
 


### PR DESCRIPTION
## Summary
- Normalize legacy app icon scaling based on the icon's actual visible bounds instead of a fixed scale.
- Derive a better background plate color for non-themed legacy icons from the icon content so the mask feels less oversized.

## Root cause
Some legacy app icons include extra transparent or padded space. The previous renderer applied one fixed scale and a generic background plate, which could make the shaped wrapper look too large and leave the app thumbnail under-filled.

## Validation
- `./gradlew.bat :app:compileDebugKotlin`
- `./gradlew.bat :app:assembleDebug`

## Note
This was build-verified locally but not manually spot-checked on-device.
