### PR TITLE
Restore legacy icon fit without repeated bitmap analysis

### DIFF
--- a/app/src/main/java/com/jeerovan/comfer/AppInfoViewModel.kt
+++ b/app/src/main/java/com/jeerovan/comfer/AppInfoViewModel.kt
@@ -47,8 +47,10 @@ import kotlinx.coroutines.flow.map
 
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.min
 private const val REST_LIST_NAME = "Rest"
+private const val ICON_ANALYSIS_SIZE = 192
 private const val ICON_ALPHA_THRESHOLD = 32
 
 data class AppInfoUiState(
@@ -74,6 +76,19 @@ data class AppInfo(
     val componentName: ComponentName,
     val user: UserHandle // Important for work profiles
 )
+
+private data class LegacyIconAnalysis(
+    val scale: Float,
+    val propagatedColor: Int?,
+)
+
+private object LegacyIconAnalysisCache {
+    private val analyses = ConcurrentHashMap<String, LegacyIconAnalysis>()
+
+    fun getOrPut(cacheKey: String, block: () -> LegacyIconAnalysis): LegacyIconAnalysis {
+        return analyses.getOrPut(cacheKey, block)
+    }
+}
 
 private val packageManagerDispatcher = Dispatchers.IO.limitedParallelism(2)
 suspend fun getAppInfo(
@@ -117,7 +132,7 @@ suspend fun getAppInfo(
         val foregroundColor = getThemedIconColor(themedColors, isLightHour)
 
         val isAdaptive = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && iconDrawable is AdaptiveIconDrawable
-        var scale = if (isAdaptive) 1.5f else 0.9f
+        var scale = if (isAdaptive) 1.5f else 1f
 
         // 4. Heavy Image Processing (CPU bound, but fine inside IO context)
         if (isAdaptive && iconDrawable is AdaptiveIconDrawable) {
@@ -147,10 +162,32 @@ suspend fun getAppInfo(
             }
         } else {
             // Legacy / Standard Icons
-            val backgroundColor = if (showThemedIcons) {
+            val legacyAnalysis = LegacyIconAnalysisCache.getOrPut(
+                "$cacheKey|${iconPackPackage.orEmpty()}"
+            ) {
+                val iconBitmap = iconDrawable.toBitmap(
+                    width = ICON_ANALYSIS_SIZE,
+                    height = ICON_ANALYSIS_SIZE,
+                    config = Bitmap.Config.ARGB_8888
+                )
+                LegacyIconAnalysis(
+                    scale = calculateLegacyForegroundScale(iconBitmap),
+                    propagatedColor = derivePropagatedSourceColor(iconBitmap),
+                )
+            }
+            val fallbackBackgroundColor = if (showThemedIcons) {
                 getThemedBackgroundColor(themedColors, isLightHour)
             } else {
                 getBackgroundColor(isLightHour).toArgb()
+            }
+            scale = legacyAnalysis.scale
+            val backgroundColor = if (showThemedIcons) {
+                fallbackBackgroundColor
+            } else {
+                blendLegacyBackgroundColor(
+                    propagatedColor = legacyAnalysis.propagatedColor,
+                    fallbackColor = fallbackBackgroundColor,
+                )
             }
             backgroundDrawable = backgroundColor.toDrawable()
 
@@ -181,6 +218,74 @@ suspend fun getAppInfo(
         Log.e("getAppInfo", "Failed to load ${info.componentName.packageName}: ${e.message}")
         null
     }
+}
+
+private fun calculateLegacyForegroundScale(bitmap: Bitmap): Float {
+    val bounds = findOpaqueBounds(bitmap) ?: return 1f
+    val contentFraction = max(
+        bounds.width().toFloat() / bitmap.width,
+        bounds.height().toFloat() / bitmap.height
+    )
+    return (0.707f / contentFraction).coerceIn(0.8f, 1.15f)
+}
+
+private fun derivePropagatedSourceColor(bitmap: Bitmap): Int? {
+    val edgeColor = sampleEdgeColor(bitmap)
+    return edgeColor ?: Palette.from(bitmap)
+        .clearFilters()
+        .maximumColorCount(12)
+        .generate()
+        .run {
+            dominantSwatch?.rgb
+                ?: mutedSwatch?.rgb
+                ?: vibrantSwatch?.rgb
+                ?: lightMutedSwatch?.rgb
+                ?: darkMutedSwatch?.rgb
+        }
+}
+
+private fun blendLegacyBackgroundColor(propagatedColor: Int?, fallbackColor: Int): Int {
+    val sourceColor = propagatedColor ?: fallbackColor
+    return ColorUtils.blendARGB(
+        ColorUtils.setAlphaComponent(sourceColor, 255),
+        ColorUtils.setAlphaComponent(fallbackColor, 255),
+        0.15f
+    )
+}
+
+private fun sampleEdgeColor(bitmap: Bitmap): Int? {
+    val edgeInsetX = max(1, bitmap.width / 8)
+    val edgeInsetY = max(1, bitmap.height / 8)
+    var red = 0L
+    var green = 0L
+    var blue = 0L
+    var sampleCount = 0
+
+    for (y in 0 until bitmap.height) {
+        for (x in 0 until bitmap.width) {
+            val isEdgePixel =
+                x < edgeInsetX || x >= bitmap.width - edgeInsetX ||
+                    y < edgeInsetY || y >= bitmap.height - edgeInsetY
+            if (!isEdgePixel) continue
+
+            val pixel = bitmap[x, y]
+            if (android.graphics.Color.alpha(pixel) < ICON_ALPHA_THRESHOLD) continue
+
+            red += android.graphics.Color.red(pixel)
+            green += android.graphics.Color.green(pixel)
+            blue += android.graphics.Color.blue(pixel)
+            sampleCount++
+        }
+    }
+
+    if (sampleCount < 24) return null
+
+    return android.graphics.Color.argb(
+        255,
+        (red / sampleCount).toInt(),
+        (green / sampleCount).toInt(),
+        (blue / sampleCount).toInt()
+    )
 }
 
 


### PR DESCRIPTION
## Summary

This restores the legacy icon fit improvement that regressed after the earlier icon normalization change was reverted for performance reasons.

## What changed

- restores content-aware sizing for legacy icons so smaller thumbnails fill the shaped wrapper more consistently
- derives a softer background color for legacy icons from the icon content instead of always falling back to the generic plate
- caches the legacy icon analysis by icon key so repeated loads do not recreate the bitmap and palette work every time

## Root cause

The earlier fix was reverted because the bitmap analysis was considered too heavy when done on every load. That brought back the fixed-scale path, which leaves some legacy icons visibly undersized inside their wrappers.

## Validation

- `:app:compileDebugKotlin`

Compile was verified locally from a clean copy of current `main` with JDK 17 and the Android SDK installed.
