### PR TITLE
Fix wallpaper restore when image metadata is missing

### DIFF
--- a/app/src/main/java/com/jeerovan/comfer/MainViewModel.kt
+++ b/app/src/main/java/com/jeerovan/comfer/MainViewModel.kt
@@ -122,9 +122,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                     }
                     delay(500)
                     // update uiState
-                    val imageData = PreferenceManager.getImageData(applicationContext)
                     val filePath = PreferenceManager.getBackgroundImagePath(applicationContext)
-                    if (imageData != null && filePath != null) {
+                    if (filePath != null) {
                         withContext(Dispatchers.IO){
                             val imageFile = File(filePath)
                             setWallpaperThemedColors(applicationContext, imageFile)


### PR DESCRIPTION
## Summary

Closes #10.

This fixes a wallpaper restore bug where Comfer could fall back to the default background after the app had been in the background for a while, even though the selected wallpaper file still existed.

## Root cause

`MainViewModel.loadBackgroundData()` only restored the current wallpaper when both `imageData` and `backgroundImagePath` were present. That works for remote wallpapers, but local and already-downloaded wallpapers can legitimately have a saved file path without fresh `imageData`.

When that happened, Comfer skipped restoring the saved wallpaper path and the launcher UI fell back to the default background instead.

## What changed

- restore the current wallpaper whenever a saved `backgroundImagePath` exists
- stop requiring `imageData` to be present before reloading the visible wallpaper

## Validation

- `:app:compileDebugKotlin`

Validated locally from a fresh copy of current `main` with JDK 17 and the Android SDK installed.
