### PR TITLE
Make scroll fling shorter and autolock snappier

### DIFF
--- a/app/src/main/java/com/jeerovan/comfer/MainActivity.kt
+++ b/app/src/main/java/com/jeerovan/comfer/MainActivity.kt
@@ -2543,7 +2543,7 @@ fun AppListOverlay(apps: List<AppInfo>,
                 targetValue = snapTarget,
                 animationSpec = spring(
                     dampingRatio = Spring.DampingRatioNoBouncy,
-                    stiffness = Spring.StiffnessLow
+                    stiffness = Spring.StiffnessHigh
                 ),
                 initialVelocity = handoffVelocity // Seamless transfer of momentum
             )
@@ -2654,7 +2654,7 @@ fun AppListOverlay(apps: List<AppInfo>,
                     },
                     onDragEnd = {
                         if (dragAxis == DragAxis.HORIZONTAL) {
-                            val velocity = velocityTracker.calculateVelocity().x * 0.3f
+                            val velocity = velocityTracker.calculateVelocity().x * 0.15f
                             scope.launch {
                                 settleOnNearestApp(velocity)
                             }


### PR DESCRIPTION
## Summary
- Reduced velocity multiplier from `0.3f` to `0.15f` to make fling distance shorter
- Increased snap stiffness from `StiffnessLow` to `StiffnessHigh` for snappier autolock

## Changes
- Line 2657: `velocityTracker.calculateVelocity().x * 0.15f`
- Line 2546: `stiffness = Spring.StiffnessHigh`

## Note
Feel free to adjust stiffness if too high - I can dial it back if needed.