### PR TITLE
fix: include quick apps in app drawer and search overlay

### DIFF
--- a/app/src/main/java/com/jeerovan/comfer/MainActivity.kt
+++ b/app/src/main/java/com/jeerovan/comfer/MainActivity.kt
@@ -3048,7 +3048,7 @@ fun LauncherScreen(appInfoViewModel: AppInfoViewModel,
         ) {
             if (settingInfoUiState.appDrawerLayout == "circular") {
                 AppListOverlay(
-                    apps = sortedPrimaryApps,
+                    apps = quickApps + sortedPrimaryApps,
                     notificationPackages,
                     onSwipeDown = { isAppListVisible = false })
             } else {
@@ -3066,7 +3066,7 @@ fun LauncherScreen(appInfoViewModel: AppInfoViewModel,
             enter = layer2Enter,
             exit = layer2Exit
         ) {
-            SearchListOverlay (apps = primaryApps+hiddenApps,
+            SearchListOverlay (apps = quickApps + primaryApps + hiddenApps,
                 notificationPackages,
                 contacts,
                 onSwipeDown = { isSearchListVisible = false },

--- a/app/src/main/java/com/jeerovan/comfer/ProSettingsActivity.kt
+++ b/app/src/main/java/com/jeerovan/comfer/ProSettingsActivity.kt
@@ -1706,7 +1706,7 @@ fun AppDrawerScreen(
     val hapticFeedback = LocalHapticFeedback.current
     val settings by settingsViewModel.uiState.collectAsState()
     val appsInfo by appInfoViewModel.uiState.collectAsState()
-    val sortedPrimaryApps = if(settings.arrangeInAlphabeticalOrder) appsInfo.primaryApps.sortedBy { it.label } else appsInfo.primaryApps
+    val sortedPrimaryApps = if(settings.arrangeInAlphabeticalOrder) (appsInfo.quickApps + appsInfo.primaryApps).sortedBy { it.label } else appsInfo.quickApps + appsInfo.primaryApps
 
     var currentApps by remember(sortedPrimaryApps) { mutableStateOf(sortedPrimaryApps) }
     val maxScreenHeightDp = with(LocalDensity.current) { LocalConfiguration.current.screenHeightDp.dp }
@@ -1740,7 +1740,12 @@ fun AppDrawerScreen(
             canReOrder = !settings.arrangeInAlphabeticalOrder,
             notificationPackages = notificationPackages,
             onAppsReordered = { from,to ->
-                appInfoViewModel.moveAppInList(AppInfoManager.PRIMARY_APPS_LIST_NAME,from,to)
+                val quickSize = appsInfo.quickApps.size
+                if (from >= quickSize && to >= quickSize) {
+                    appInfoViewModel.moveAppInList(AppInfoManager.PRIMARY_APPS_LIST_NAME, from - quickSize, to - quickSize)
+                } else if (from < quickSize && to < quickSize) {
+                    appInfoViewModel.moveAppInList(AppInfoManager.QUICK_APPS_LIST_NAME, from, to)
+                }
             },
             initialHeight = drawerHeight,
             initialOffsetY = drawerOffset,


### PR DESCRIPTION
## Summary

- Quick apps (the 8 apps in the home screen circle) were excluded from the full app drawer (swipe up), the search overlay, and the circular app list overlay
- This fix includes quick apps alongside primary apps in all three views so users can see all their apps in one place

## Changes

- **AppListOverlay** (circular drawer): Now includes `quickApps` before `sortedPrimaryApps`
- **AppDrawerScreen** (grid drawer): Now includes `quickApps` before `primaryApps`, with offset-aware reorder handling
- **SearchListOverlay** (search screen): Now includes `quickApps` alongside `primaryApps + hiddenApps`